### PR TITLE
Version lock tauri to 1.2

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.2", features = [] }
 
 [dependencies]
-tauri = { version = "1.2", features = ["shell-open"] }
+tauri = { version = "=1.2", features = ["shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri-egui = "0.1"


### PR DESCRIPTION
This project fails to compile if you run cargo update, it updates to tauri 1.3/4 which does not work with tauri-egui